### PR TITLE
Improve query predicate error handling and add Rust integration tests

### DIFF
--- a/tree-sitter-rust/src/test/java/org/treesitter/TreeSitterRustTest.java
+++ b/tree-sitter-rust/src/test/java/org/treesitter/TreeSitterRustTest.java
@@ -6,6 +6,7 @@ import org.treesitter.tests.CorpusTest;
 import java.io.IOException;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class TreeSitterRustTest {
@@ -65,16 +66,84 @@ class TreeSitterRustTest {
     }
 
     @Test
-    void testIntegrationQueryNotEq() {
+    void testIntegrationQueryNotEqShouldNotMatch() {
         TSParser parser = new TSParser();
         parser.setLanguage(new TreeSitterRust());
-        // Note: Corrected snippet from prompt (removed extra ')')
+
+        String source = "#[derive(Other)] \n" +
+                "pub enum Status {\n" +
+                "  Running,\n" +
+                "  Stopped,\n" +
+                "  Initial,\n" +
+                "}";
+
+        TSTree tree = parser.parseString(null, source);
+        TSNode rootNode = tree.getRootNode();
+
+        String queryString = "(attribute_item\n" +
+                "  (attribute\n" +
+                "    (identifier) @_derive\n" +
+                "    (#not-eq? @_derive \"derive\")\n" +
+                "    (token_tree\n" +
+                "      (identifier) @macro.derive.name\n" +
+                "    )\n" +
+                "  )\n" +
+                ") @macro.derive";
+
+        TSQuery query = new TSQuery(parser.getLanguage(), queryString);
+        TSQueryCursor cursor = new TSQueryCursor();
+        cursor.exec(query, rootNode, source);
+
+        TSQueryMatch match = new TSQueryMatch();
+        assertFalse(cursor.nextMatch(match), "Query should not match because #not-eq? predicate fails");
+    }
+
+    @Test
+    void testIntegrationQueryEqShouldNotMatch() {
+        TSParser parser = new TSParser();
+        parser.setLanguage(new TreeSitterRust());
+
+        String source = "#[foo(Other)] \n" +
+                "pub enum Status {\n" +
+                "  Running,\n" +
+                "  Stopped,\n" +
+                "  Initial,\n" +
+                "}";
+
+        TSTree tree = parser.parseString(null, source);
+        TSNode rootNode = tree.getRootNode();
+
+        String queryString = "(attribute_item\n" +
+                "  (attribute\n" +
+                "    (identifier) @_derive\n" +
+                "    (#eq? @_derive \"derive\")\n" +
+                "    (token_tree\n" +
+                "      (identifier) @macro.derive.name\n" +
+                "    )\n" +
+                "  )\n" +
+                ") @macro.derive";
+
+        TSQuery query = new TSQuery(parser.getLanguage(), queryString);
+        TSQueryCursor cursor = new TSQueryCursor();
+        cursor.exec(query, rootNode, source);
+
+        TSQueryMatch match = new TSQueryMatch();
+        assertFalse(cursor.nextMatch(match), "Query should not match because #eq? predicate fails");
+    }
+
+
+    @Test
+    void testIntegrationQueryNotEqShouldMatch() {
+        TSParser parser = new TSParser();
+        parser.setLanguage(new TreeSitterRust());
+
         String source = "#[is_macro::Is]\n" +
                 "pub enum Status {\n" +
                 "  Running,\n" +
                 "  Stopped,\n" +
                 "  Initial,\n" +
                 "}";
+
         TSTree tree = parser.parseString(null, source);
         TSNode rootNode = tree.getRootNode();
 

--- a/tree-sitter-rust/src/test/java/org/treesitter/TreeSitterRustTest.java
+++ b/tree-sitter-rust/src/test/java/org/treesitter/TreeSitterRustTest.java
@@ -5,9 +5,56 @@ import org.treesitter.tests.CorpusTest;
 
 import java.io.IOException;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 class TreeSitterRustTest {
     @Test
     void corpusTest() throws IOException {
         CorpusTest.runAllTestsInDefaultFolder(new TreeSitterRust(), "rust");
+    }
+
+    @Test
+    void testIntegrationQuery() {
+        TSParser parser = new TSParser();
+        parser.setLanguage(new TreeSitterRust());
+        String source = "#[derive(Is)] \n" +
+                "pub enum Status {\n" +
+                "  Running,\n" +
+                "  Stopped,\n" +
+                "  Initial,\n" +
+                "}";
+        TSTree tree = parser.parseString(null, source);
+        TSNode rootNode = tree.getRootNode();
+
+        String queryString = "(attribute_item\n" +
+                "  (attribute\n" +
+                "    (identifier) @_derive\n" +
+                "    (#eq? @_derive \"derive\")\n" +
+                "    (token_tree\n" +
+                "      (identifier) @macro.derive.name\n" +
+                "    )\n" +
+                "  )\n" +
+                ") @macro.derive";
+
+        TSQuery query = new TSQuery(parser.getLanguage(), queryString);
+        TSQueryCursor cursor = new TSQueryCursor();
+        cursor.exec(query, rootNode, source);
+
+        TSQueryMatch match = new TSQueryMatch();
+        assertTrue(cursor.nextMatch(match), "Query should have matched");
+
+        boolean foundMacroDerive = false;
+        for (TSQueryCapture capture : match.getCaptures()) {
+            String captureName = query.getCaptureNameForId(capture.getIndex());
+            if ("macro.derive".equals(captureName)) {
+                foundMacroDerive = true;
+                TSNode node = capture.getNode();
+                String matchedText = source.substring(node.getStartByte(), node.getEndByte());
+                assertTrue(matchedText.contains("#[derive(Is)]"), 
+                    "Matched text should contain the attribute. Found: " + matchedText);
+            }
+        }
+        assertTrue(foundMacroDerive, "Should have found @macro.derive capture");
     }
 }

--- a/tree-sitter-rust/src/test/java/org/treesitter/TreeSitterRustTest.java
+++ b/tree-sitter-rust/src/test/java/org/treesitter/TreeSitterRustTest.java
@@ -45,16 +45,72 @@ class TreeSitterRustTest {
         assertTrue(cursor.nextMatch(match), "Query should have matched");
 
         boolean foundMacroDerive = false;
+        boolean foundDeriveName = false;
         for (TSQueryCapture capture : match.getCaptures()) {
             String captureName = query.getCaptureNameForId(capture.getIndex());
+            TSNode node = capture.getNode();
+            String matchedText = source.substring(node.getStartByte(), node.getEndByte());
+
             if ("macro.derive".equals(captureName)) {
                 foundMacroDerive = true;
-                TSNode node = capture.getNode();
-                String matchedText = source.substring(node.getStartByte(), node.getEndByte());
-                assertTrue(matchedText.contains("#[derive(Is)]"), 
+                assertTrue(matchedText.contains("#[derive(Is)]"),
                     "Matched text should contain the attribute. Found: " + matchedText);
+            } else if ("macro.derive.name".equals(captureName)) {
+                foundDeriveName = true;
+                assertEquals("Is", matchedText, "macro.derive.name should match 'Is'");
             }
         }
         assertTrue(foundMacroDerive, "Should have found @macro.derive capture");
+        assertTrue(foundDeriveName, "Should have found @macro.derive.name capture");
+    }
+
+    @Test
+    void testIntegrationQueryNotEq() {
+        TSParser parser = new TSParser();
+        parser.setLanguage(new TreeSitterRust());
+        // Note: Corrected snippet from prompt (removed extra ')')
+        String source = "#[is_macro::Is]\n" +
+                "pub enum Status {\n" +
+                "  Running,\n" +
+                "  Stopped,\n" +
+                "  Initial,\n" +
+                "}";
+        TSTree tree = parser.parseString(null, source);
+        TSNode rootNode = tree.getRootNode();
+
+        String queryString = "(attribute_item\n" +
+                "  (attribute\n" +
+                "    [\n" +
+                "      ((identifier) @macro.attribute.name\n" +
+                "        (#not-eq? @macro.attribute.name \"derive\"))\n" +
+                "      (scoped_identifier) @macro.attribute.name\n" +
+                "    ]\n" +
+                "  )\n" +
+                ") @macro.attribute";
+
+        TSQuery query = new TSQuery(parser.getLanguage(), queryString);
+        TSQueryCursor cursor = new TSQueryCursor();
+        cursor.exec(query, rootNode, source);
+
+        TSQueryMatch match = new TSQueryMatch();
+        assertTrue(cursor.nextMatch(match), "Query should have matched is_macro::Is");
+
+        boolean foundAttribute = false;
+        boolean foundName = false;
+        for (TSQueryCapture capture : match.getCaptures()) {
+            String captureName = query.getCaptureNameForId(capture.getIndex());
+            TSNode node = capture.getNode();
+            String matchedText = source.substring(node.getStartByte(), node.getEndByte());
+
+            if ("macro.attribute".equals(captureName)) {
+                foundAttribute = true;
+                assertTrue(matchedText.contains("#[is_macro::Is]"));
+            } else if ("macro.attribute.name".equals(captureName)) {
+                foundName = true;
+                assertEquals("is_macro::Is", matchedText);
+            }
+        }
+        assertTrue(foundAttribute, "Should have found @macro.attribute capture");
+        assertTrue(foundName, "Should have found @macro.attribute.name capture");
     }
 }

--- a/tree-sitter/src/main/java/org/treesitter/TSQueryPredicate.java
+++ b/tree-sitter/src/main/java/org/treesitter/TSQueryPredicate.java
@@ -41,12 +41,12 @@ public abstract class TSQueryPredicate {
      */
     public boolean test(TSQueryMatch match, byte[] sourceBytes) {
         return test(match, n -> {
-            if (n == null || n.isNull() || sourceBytes == null) return "";
+            if (n == null || n.isNull()) return "";
+            if (sourceBytes == null || n.getStartByte() < 0 || n.getStartByte() > n.getEndByte() || n.getStartByte() >= sourceBytes.length) {
+                throw new IllegalStateException("Source bytes are required to evaluate text-based predicates");
+            }
             int start = n.getStartByte();
             int end = n.getEndByte();
-            if (start < 0 || start > end || start >= sourceBytes.length) {
-                return "";
-            }
             int length = Math.min(end, sourceBytes.length) - start;
             return new String(sourceBytes, start, length, java.nio.charset.StandardCharsets.UTF_8);
         });

--- a/tree-sitter/src/test/java/org/treesitter/TSQueryPredicateTest.java
+++ b/tree-sitter/src/test/java/org/treesitter/TSQueryPredicateTest.java
@@ -129,4 +129,21 @@ class TSQueryPredicateTest {
         assertTrue(cursor.nextMatch(match), "Should match '世界' using partial regex");
         assertFalse(cursor.nextMatch(match));
     }
+
+    @Test
+    void testMissingSourceBytesThrowsException() {
+        // [1, null]
+        // Use a simple query that matches something but doesn't have its own predicates
+        query = new TSQuery(json, "((number) @val)");
+        cursor.exec(query, rootNode, JSON_SRC);
+        TSQueryMatch match = new TSQueryMatch();
+        assertTrue(cursor.nextMatch(match));
+
+        // Manually create a predicate to test the exception throwing behavior.
+        // Capture index 0 is '@val' from the query above.
+        TSQueryPredicate predicate = new TSQueryPredicate.TSQueryPredicateEq("eq?", 0, "1", -1, false);
+
+        // Attempting to test predicates with null sourceBytes should throw IllegalStateException
+        assertThrows(IllegalStateException.class, () -> predicate.test(match, (byte[]) null));
+    }
 }


### PR DESCRIPTION
This pull request improves the robustness of query predicate evaluation and expands test coverage for the Rust language bindings.

Key changes include:
- **Predicate Validation:** Updated `TSQueryPredicate` to throw an `IllegalStateException` when source bytes are missing or invalid during text-based predicate evaluation (e.g., `#eq?`, `#match?`). This replaces silent failures with explicit error reporting.
- **Rust Integration Tests:** Added new integration tests in `TreeSitterRustTest` that verify complex query scenarios, including usage of `#eq?` and `#not-eq?` predicates on Rust attributes and macro derive names.
- **Enhanced Test Suite:** Added unit tests in `TSQueryPredicateTest` to verify that the library correctly handles and reports missing source data.

These changes ensure that developers receive clear feedback when query execution environment is misconfigured.