### PR TITLE
Add Android arm64 native target support

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ class Main {
 - aarch64-macos
 - x86_64-linux
 - aarch64-linux
+- aarch64-linux-android
 
 # Developers: How to Add a Parser
 

--- a/buildSrc/src/main/groovy/BuildNativeTask.groovy
+++ b/buildSrc/src/main/groovy/BuildNativeTask.groovy
@@ -19,7 +19,7 @@ class BuildNativeTask extends DefaultTask{
     static String libExt(String target){
         if(target.contains("windows")){
             return "dll"
-        }else if(target.contains("linux")){
+        }else if(target.contains("linux") || target.contains("android")){
             return "so"
         }else if(target.contains("macos")){
             return "dylib"
@@ -134,7 +134,7 @@ class BuildNativeTask extends DefaultTask{
         Directory jniInclude = jniIncludeDir
         if(target.contains("windows")){
             return jniInclude.dir("win32")
-        }else if(target.contains("linux")){
+        }else if(target.contains("linux") || target.contains("android")){
             return jniInclude.dir("linux")
         }else if(target.contains("macos")){
             return jniInclude.dir("darwin")

--- a/buildSrc/src/main/groovy/org/treesitter/build/Utils.groovy
+++ b/buildSrc/src/main/groovy/org/treesitter/build/Utils.groovy
@@ -90,7 +90,7 @@ abstract class Utils {
         Directory jniInclude = jniIncludeDir(project)
         if(target.contains("windows")){
             return jniInclude.dir("win32")
-        }else if(target.contains("linux")){
+        }else if(target.contains("linux") || target.contains("android")){
             return jniInclude.dir("linux")
         }else if(target.contains("macos")){
             return jniInclude.dir("darwin")
@@ -102,7 +102,7 @@ abstract class Utils {
     static String libExt(String target){
         if(target.contains("windows")){
             return "dll"
-        }else if(target.contains("linux")){
+        }else if(target.contains("linux") || target.contains("android")){
             return "so"
         }else if(target.contains("macos")){
             return "dylib"

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,6 +4,6 @@ zigDir=zig
 zigVersion=0.11.0
 miniSignVersion=0.11
 zigPubKey=RWSGOq2NVecA2UPNdBUZykf1CCb147pkmdtYxgb3Ti+JO/wCYvhbAb/U
-treeSitterTargets=x86_64-windows,x86_64-macos,x86_64-linux-gnu,aarch64-linux-gnu,aarch64-macos
+treeSitterTargets=x86_64-windows,x86_64-macos,x86_64-linux-gnu,aarch64-linux-gnu,aarch64-macos,aarch64-linux-android
 org.gradle.parallel=true
 org.gradle.workers.max=4

--- a/tree-sitter/src/main/java/org/treesitter/utils/NativeUtils.java
+++ b/tree-sitter/src/main/java/org/treesitter/utils/NativeUtils.java
@@ -14,10 +14,17 @@ public abstract class NativeUtils {
     private static String getFullLibName(String libName){
         String osName = System.getProperty("os.name").toLowerCase();
         String archName = System.getProperty("os.arch").toLowerCase();
+        String vmName = System.getProperty("java.vm.name", "").toLowerCase();
+        String runtimeName = System.getProperty("java.runtime.name", "").toLowerCase();
         String ext;
         String os;
         String arch;
-        if(osName.contains("windows")){
+
+        boolean isAndroid = vmName.contains("dalvik") || runtimeName.contains("android");
+        if (isAndroid) {
+            ext = "so";
+            os = "linux-android";
+        } else if(osName.contains("windows")){
             ext = "dll";
             os = "windows";
         }else if(osName.contains("linux")){

--- a/tree-sitter/src/test/java/org/treesitter/utils/NativeUtilsTest.java
+++ b/tree-sitter/src/test/java/org/treesitter/utils/NativeUtilsTest.java
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.io.IOException;
+import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -56,6 +57,39 @@ class NativeUtilsTest {
                 NativeUtils.loadLib("lib/tree-sitter");
             });
             thread.start();
+        }
+    }
+
+    @Test
+    void fullLibNameUsesAndroidTarget() throws Exception {
+        String oldOsName = System.getProperty("os.name");
+        String oldOsArch = System.getProperty("os.arch");
+        String oldVmName = System.getProperty("java.vm.name");
+        String oldRuntimeName = System.getProperty("java.runtime.name");
+        try {
+            System.setProperty("os.name", "Linux");
+            System.setProperty("os.arch", "aarch64");
+            System.setProperty("java.vm.name", "Dalvik");
+            System.setProperty("java.runtime.name", "Android Runtime");
+
+            Method getFullLibName = NativeUtils.class.getDeclaredMethod("getFullLibName", String.class);
+            getFullLibName.setAccessible(true);
+            String fullName = (String) getFullLibName.invoke(null, "lib/tree-sitter");
+
+            assertEquals("lib/aarch64-linux-android-tree-sitter.so", fullName);
+        } finally {
+            restoreProperty("os.name", oldOsName);
+            restoreProperty("os.arch", oldOsArch);
+            restoreProperty("java.vm.name", oldVmName);
+            restoreProperty("java.runtime.name", oldRuntimeName);
+        }
+    }
+
+    private static void restoreProperty(String key, String value) {
+        if (value == null) {
+            System.clearProperty(key);
+        } else {
+            System.setProperty(key, value);
         }
     }
 }


### PR DESCRIPTION
## Summary
- add Android runtime detection in `NativeUtils` and resolve native filenames as `*-linux-android-*.so`
- allow Android targets in native build utilities (`BuildNativeTask` and `Utils`)
- add `aarch64-linux-android` to default `treeSitterTargets`
- document Android target in README
- add test coverage for Android filename resolution in `NativeUtilsTest`

## Why
Android commonly reports `os.name` as Linux, so runtime loading falls back to `linux-gnu` artifacts. This patch introduces explicit Android detection and build target support so Android-native artifacts can be produced and loaded consistently.

## Validation
- `./gradlew :tree-sitter:compileJava :tree-sitter-java:compileJava :tree-sitter-javascript:compileJava --no-daemon`
- `./gradlew :tree-sitter:test --tests org.treesitter.utils.NativeUtilsTest.fullLibNameUsesAndroidTarget --no-daemon`
